### PR TITLE
🐛 fix(posthog): capture SPA pageviews on history changes

### DIFF
--- a/src/providers/posthog.test.ts
+++ b/src/providers/posthog.test.ts
@@ -1,0 +1,57 @@
+import { posthog } from 'posthog-js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PostHogAnalyticsProvider } from './posthog';
+
+vi.mock('posthog-js', () => ({
+  posthog: {
+    init: vi.fn(),
+  },
+}));
+
+describe('PostHogAnalyticsProvider', () => {
+  const init = vi.mocked(posthog.init);
+
+  beforeEach(() => {
+    init.mockClear();
+  });
+
+  it('defaults pageview capture to history changes for SPA navigation', async () => {
+    const provider = new PostHogAnalyticsProvider(
+      {
+        enabled: true,
+        key: 'test-key',
+      },
+      'test',
+    );
+
+    await provider.initialize();
+
+    expect(init).toHaveBeenCalledWith(
+      'test-key',
+      expect.objectContaining({
+        capture_pageview: 'history_change',
+      }),
+    );
+  });
+
+  it('keeps an explicit pageview capture override', async () => {
+    const provider = new PostHogAnalyticsProvider(
+      {
+        capture_pageview: false,
+        enabled: true,
+        key: 'test-key',
+      },
+      'test',
+    );
+
+    await provider.initialize();
+
+    expect(init).toHaveBeenCalledWith(
+      'test-key',
+      expect.objectContaining({
+        capture_pageview: false,
+      }),
+    );
+  });
+});

--- a/src/providers/posthog.ts
+++ b/src/providers/posthog.ts
@@ -33,6 +33,7 @@ export class PostHogAnalyticsProvider extends BaseAnalytics {
       const initConfig = {
         ...posthogConfig, // User's posthog-js config options
         api_host: host || posthogConfig.api_host || 'https://app.posthog.com',
+        capture_pageview: posthogConfig.capture_pageview ?? 'history_change',
         // Use before_send to dynamically add business context to all events
         before_send: this.createBeforeSendHandler(posthogConfig.before_send),
         debug: this.debug,


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 Description of Change

- Default PostHog browser pageview capture to `history_change` so SPA navigation via the History API emits `$pageview` events.
- Preserve explicit caller overrides such as `capture_pageview: false`.
- Add focused unit coverage for the default and override behavior.

#### 📝 Additional Information

Validation:

- `pnpm exec vitest run src/providers/posthog.test.ts`
- `pnpm exec tsc --noEmit`
